### PR TITLE
Fixing cdrpub.py 

### DIFF
--- a/Python/cdrpub.py
+++ b/Python/cdrpub.py
@@ -129,6 +129,8 @@ class Control:
                 message = "Processing script {!r} not found".format(script)
                 raise Exception(message)
             command = "{} {:d}".format(script, self.job.id)
+            if script.endswith(".py") and "python" not in command.lower():
+                command = " ".join([cdr.PYTHON, command])
             self.logger.info("Launching %s", command)
             os.system(command)
 


### PR DESCRIPTION
Adding path of Python interpreter when submitting scripts, i.e. Mailers. OCECDR-4546