### PR TITLE
Fix link to overview diagram

### DIFF
--- a/Python/cdrapi/README.md
+++ b/Python/cdrapi/README.md
@@ -77,4 +77,4 @@ The `reports` provides support for common reports, via the
 ## Architectural overview
 Here is how the new CDR API fits into the CDR server's architecture.
 
-![Overview](https://github.com/NCIOCPL/cdr-lib/raw/gauss/Python/cdrapi/CDR.jpg)
+![Overview](https://github.com/NCIOCPL/cdr-lib/raw/master/Python/cdrapi/CDR.jpg)


### PR DESCRIPTION
The link was to the `git` branch for which this directory was created. That branch has been merged into `master` and deleted. The link is fixed to point to the image in `master`.